### PR TITLE
Add pytest tests and CI coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,41 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    services:
+      mysql:
+        image: mysql:8
+        env:
+          MYSQL_ROOT_PASSWORD: root
+          MYSQL_DATABASE: appdb
+        ports:
+          - 3306:3306
+        options: >-
+          --health-cmd="mysqladmin ping --silent"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=3
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v3
+        with:
+          python-version: '3.10'
+      - name: Install dependencies
+        run: |
+          cd backend
+          pip install -r requirements.txt
+      - name: Run tests
+        run: |
+          cd backend
+          pytest --cov=app --cov-report=xml:coverage.xml
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v3
+        with:
+          files: backend/coverage.xml

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -5,3 +5,6 @@ pymysql
 python-dotenv
 pydantic[email]
 cryptography
+
+pytest
+pytest-cov

--- a/backend/tests/test_users.py
+++ b/backend/tests/test_users.py
@@ -1,0 +1,73 @@
+import pytest
+from fastapi.testclient import TestClient
+from app.main import app
+
+client = TestClient(app)
+
+
+def test_create_user(monkeypatch):
+    class DummyUser:
+        def __init__(self):
+            self.id = 1
+            self.first_name = "John"
+            self.last_name = "Doe"
+            self.email = "john@example.com"
+
+    def fake_create_user(user):
+        return DummyUser()
+
+    monkeypatch.setattr("app.crud.create_user", fake_create_user)
+
+    payload = {
+        "first_name": "John",
+        "last_name": "Doe",
+        "email": "john@example.com",
+        "password": "secret",
+    }
+    response = client.post("/users/", json=payload)
+    assert response.status_code == 200
+    data = response.json()
+    assert data["id"] == 1
+    assert data["first_name"] == "John"
+
+
+def test_read_users(monkeypatch):
+    class DummyUser:
+        def __init__(self, uid):
+            self.id = uid
+            self.first_name = f"First{uid}"
+            self.last_name = f"Last{uid}"
+            self.email = f"user{uid}@example.com"
+
+    def fake_get_users():
+        return [DummyUser(1), DummyUser(2)]
+
+    monkeypatch.setattr("app.crud.get_users", fake_get_users)
+
+    response = client.get("/users/")
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data) == 2
+    assert data[0]["id"] == 1
+
+
+def test_delete_user_success(monkeypatch):
+    def fake_delete_user(user_id: int):
+        return True
+
+    monkeypatch.setattr("app.crud.delete_user", fake_delete_user)
+
+    response = client.delete("/users/1")
+    assert response.status_code == 200
+    assert response.json() == {"detail": "User deleted"}
+
+
+def test_delete_user_not_found(monkeypatch):
+    def fake_delete_user(user_id: int):
+        return False
+
+    monkeypatch.setattr("app.crud.delete_user", fake_delete_user)
+
+    response = client.delete("/users/99")
+    assert response.status_code == 404
+    assert response.json()["detail"] == "User not found"


### PR DESCRIPTION
## Summary
- add basic FastAPI tests for user routes
- include pytest and pytest-cov in backend requirements
- run tests and upload coverage in GitHub Actions CI

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_685910af4174832c9c808ff3691f980a