### PR TITLE
Add Cypress tests and basic user UI

### DIFF
--- a/cypress.config.js
+++ b/cypress.config.js
@@ -1,0 +1,8 @@
+const { defineConfig } = require('cypress')
+
+module.exports = defineConfig({
+  e2e: {
+    baseUrl: 'http://localhost:5173',
+    supportFile: false,
+  },
+})

--- a/cypress/e2e/users.cy.js
+++ b/cypress/e2e/users.cy.js
@@ -1,0 +1,13 @@
+describe('User management', () => {
+  it('creates and lists a user', () => {
+    const email = `test${Date.now()}@example.com`
+    cy.visit('/')
+    cy.get('[data-testid="first"]').type('Test')
+    cy.get('[data-testid="last"]').type('User')
+    cy.get('[data-testid="email"]').type(email)
+    cy.get('[data-testid="password"]').type('secret')
+    cy.get('[data-testid="submit"]').click()
+    cy.contains('Refresh').click()
+    cy.get('[data-testid="list"]').should('contain', email)
+  })
+})

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -1,30 +1,22 @@
 <script setup lang="ts">
-import HelloWorld from './components/HelloWorld.vue'
+import { ref } from 'vue'
+import UserForm from './components/UserForm.vue'
+import UserList from './components/UserList.vue'
+
+const listRef = ref()
+function refreshList() {
+  if (listRef.value) listRef.value.loadUsers()
+}
 </script>
 
 <template>
-  <div>
-    <a href="https://vite.dev" target="_blank">
-      <img src="/vite.svg" class="logo" alt="Vite logo" />
-    </a>
-    <a href="https://vuejs.org/" target="_blank">
-      <img src="./assets/vue.svg" class="logo vue" alt="Vue logo" />
-    </a>
-  </div>
-  <HelloWorld msg="Vite + Vue" />
+  <h1>User Management</h1>
+  <UserForm @created="refreshList" />
+  <UserList ref="listRef" />
 </template>
 
 <style scoped>
-.logo {
-  height: 6em;
-  padding: 1.5em;
-  will-change: filter;
-  transition: filter 300ms;
-}
-.logo:hover {
-  filter: drop-shadow(0 0 2em #646cffaa);
-}
-.logo.vue:hover {
-  filter: drop-shadow(0 0 2em #42b883aa);
+h1 {
+  margin-bottom: 1rem;
 }
 </style>

--- a/frontend/src/components/UserForm.vue
+++ b/frontend/src/components/UserForm.vue
@@ -1,0 +1,47 @@
+<template>
+  <form @submit.prevent="submitForm">
+    <div>
+      <label>First Name</label>
+      <input data-testid="first" v-model="form.first_name" placeholder="First name" />
+    </div>
+    <div>
+      <label>Last Name</label>
+      <input data-testid="last" v-model="form.last_name" placeholder="Last name" />
+    </div>
+    <div>
+      <label>Email</label>
+      <input data-testid="email" v-model="form.email" type="email" placeholder="Email" />
+    </div>
+    <div>
+      <label>Password</label>
+      <input data-testid="password" v-model="form.password" type="password" placeholder="Password" />
+    </div>
+    <button data-testid="submit" type="submit">Create User</button>
+  </form>
+</template>
+
+<script setup lang="ts">
+import { reactive } from 'vue'
+
+const emitSubmit = defineEmits(['created'])
+
+const form = reactive({
+  first_name: '',
+  last_name: '',
+  email: '',
+  password: '',
+})
+
+async function submitForm() {
+  await fetch('http://localhost:5001/users/', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(form),
+  })
+  emitSubmit('created')
+  form.first_name = ''
+  form.last_name = ''
+  form.email = ''
+  form.password = ''
+}
+</script>

--- a/frontend/src/components/UserList.vue
+++ b/frontend/src/components/UserList.vue
@@ -1,0 +1,31 @@
+<template>
+  <div>
+    <button @click="loadUsers">Refresh</button>
+    <ul data-testid="list">
+      <li v-for="user in users" :key="user.id">
+        {{ user.first_name }} {{ user.last_name }} - {{ user.email }}
+      </li>
+    </ul>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, onMounted } from 'vue'
+
+interface User {
+  id: number
+  first_name: string
+  last_name: string
+  email: string
+}
+
+const users = ref<User[]>([])
+
+async function loadUsers() {
+  const res = await fetch('http://localhost:5001/users/')
+  users.value = await res.json()
+}
+
+onMounted(loadUsers)
+defineExpose({ loadUsers })
+</script>

--- a/package.json
+++ b/package.json
@@ -1,5 +1,12 @@
 {
   "dependencies": {
     "react-scripts": "^5.0.1"
+  },
+  "devDependencies": {
+    "cypress": "^13.7.3"
+  },
+  "scripts": {
+    "cypress:open": "cypress open",
+    "cypress:run": "cypress run"
   }
 }


### PR DESCRIPTION
## Summary
- add simple Vue components for creating and listing users
- display these components from App.vue
- configure Cypress and write an e2e test
- add `cypress` as a dev dependency

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*
- `npx cypress --version` *(fails: 403 Forbidden fetching Cypress)*

------
https://chatgpt.com/codex/tasks/task_e_685911faf7e8832ca7e1707b43dfec2f