### PR TITLE
Add INIT_ADMIN support and remote DB docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,3 +69,22 @@ MYSQL_DATABASE: appdb
 ```
 
 Use these credentials when signing into Adminer (System: `MySQL`, Server: `mysql`, Username: `root`, Password: `root`, Database: `appdb`). Adjust the values in `docker-compose.yml` if you need different credentials before launching the containers.
+
+## Hosted MySQL setup
+
+You can deploy the application with a hosted MySQL instance (for example
+with [Aiven](https://aiven.io/) or [AlwaysData](https://www.alwaysdata.com/)).
+Set the following environment variables before starting Docker Compose:
+
+```
+DB_HOST=<remote host>
+DB_PORT=<remote port>
+DB_USER=<remote user>
+DB_PASSWORD=<remote password>
+DB_NAME=<database name>
+INIT_ADMIN=First,Last,email@example.com,password
+```
+
+`INIT_ADMIN` should contain the initial administrator credentials separated by
+commas. During application startup the backend will automatically create this
+user if it does not already exist.

--- a/backend/app/init_admin.py
+++ b/backend/app/init_admin.py
@@ -1,0 +1,30 @@
+import os
+from sqlalchemy.orm import Session
+from app.crud import SessionLocal
+from app.models import User
+
+
+def create_admin_from_env() -> None:
+    """Create an initial admin user if INIT_ADMIN is provided."""
+    creds = os.getenv("INIT_ADMIN")
+    if not creds:
+        return
+    parts = [p.strip() for p in creds.split(",")]
+    if len(parts) != 4:
+        # Invalid format; expected First,Last,email,password
+        return
+    first, last, email, password = parts
+    db: Session = SessionLocal()
+    try:
+        existing = db.query(User).filter(User.email == email).first()
+        if not existing:
+            admin = User(
+                first_name=first,
+                last_name=last,
+                email=email,
+                password=password,
+            )
+            db.add(admin)
+            db.commit()
+    finally:
+        db.close()

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,5 +1,6 @@
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
+from app.init_admin import create_admin_from_env
 
 app = FastAPI()
 
@@ -15,3 +16,9 @@ app.add_middleware(
 # Import de tes routes
 from app.routers import users  # exemple
 app.include_router(users.router)
+
+
+@app.on_event("startup")
+def startup_admin() -> None:
+    """Create the initial admin user if required."""
+    create_admin_from_env()

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,10 +29,12 @@ services:
     depends_on:
       - mysql
     environment:
-      DB_HOST: mysql
-      DB_USER: root
-      DB_PASSWORD: root
-      DB_NAME: appdb
+      DB_HOST: ${DB_HOST:-mysql}
+      DB_USER: ${DB_USER:-root}
+      DB_PASSWORD: ${DB_PASSWORD:-root}
+      DB_NAME: ${DB_NAME:-appdb}
+      DB_PORT: ${DB_PORT:-3306}
+      INIT_ADMIN: ${INIT_ADMIN:-}
 
   frontend:
     build: ./frontend


### PR DESCRIPTION
## Summary
- set backend to read INIT_ADMIN on startup
- allow docker-compose to override DB connection vars
- document hosted MySQL configuration in README

## Testing
- `pip install -r requirements.txt` *(fails: Tunnel connection failed)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6859149a7f1c832cba211cbd6f737893