### PR TITLE
Connect frontend to deployed API

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,21 @@ npm run dev
 
 The development server runs on [http://localhost:5173](http://localhost:5173).
 
+### Frontend environment variables
+
+Create a `.env` file inside `frontend/` and provide the API endpoint base URL:
+
+```bash
+VITE_API_BASE_URL=http://localhost:5001/api
+```
+
+For production deployments replace the value with your hosted backend, for
+example:
+
+```bash
+VITE_API_BASE_URL=https://user-management-1d430k7vg-yanldxs-projects.vercel.app/api
+```
+
 ## Accessing Adminer
 
 Adminer allows you to browse the database easily. After the Docker stack starts, open [http://localhost:8080](http://localhost:8080) and log in using the MySQL credentials.

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -10,8 +10,9 @@ app = FastAPI()
 
 # Pour permettre les requêtes CORS depuis localhost et prod
 origins = [
-    "http://localhost:3000",
+    "http://localhost:5173",
     "https://oursel06.github.io",
+    "https://user-management-1d430k7vg-yanldxs-projects.vercel.app",
 ]
 
 app.add_middleware(

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,1 @@
+VITE_API_BASE_URL=http://localhost:5001/api

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -1,0 +1,2 @@
+export const API_BASE_URL =
+  (import.meta as any).env.VITE_API_BASE_URL || 'http://localhost:5001/api';

--- a/frontend/src/components/UserForm.vue
+++ b/frontend/src/components/UserForm.vue
@@ -10,6 +10,7 @@
 
 <script setup lang="ts">
 import { reactive } from 'vue'
+import { API_BASE_URL } from '../api'
 const emit = defineEmits(['created'])
 
 const form = reactive({
@@ -20,7 +21,7 @@ const form = reactive({
 })
 
 async function submitForm() {
-  await fetch('http://localhost:5001/users/', {
+  await fetch(`${API_BASE_URL}/users/`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(form),

--- a/frontend/src/components/UserList.vue
+++ b/frontend/src/components/UserList.vue
@@ -12,8 +12,10 @@
 const props = defineProps<{ users: any[]; isAdmin: boolean }>()
 const emit = defineEmits(['deleted'])
 
+import { API_BASE_URL } from '../api'
+
 async function deleteUser(id: number) {
-  await fetch(`http://localhost:5001/users/${id}`, { method: 'DELETE' })
+  await fetch(`${API_BASE_URL}/users/${id}`, { method: 'DELETE' })
   emit('deleted')
 }
 </script>

--- a/frontend/src/components/UserManagement.vue
+++ b/frontend/src/components/UserManagement.vue
@@ -27,6 +27,7 @@
 
 <script setup lang="ts">
 import { ref, onMounted } from 'vue'
+import { API_BASE_URL } from '../api'
 import UserForm from './UserForm.vue'
 import UserList from './UserList.vue'
 
@@ -38,7 +39,7 @@ const error = ref('')
 const users = ref([])
 
 async function loadUsers() {
-  const res = await fetch('http://localhost:5001/users/')
+  const res = await fetch(`${API_BASE_URL}/users/`)
   users.value = await res.json()
 }
 


### PR DESCRIPTION
## Summary
- allow frontend to read API URL from `VITE_API_BASE_URL`
- document frontend `.env` usage
- permit requests from the deployed domain via CORS

## Testing
- `pytest -q` *(fails: unrecognized arguments for coverage)*

------
https://chatgpt.com/codex/tasks/task_e_685a7f3ceaa8832ca517d36789c2cd6a